### PR TITLE
Added a custom attributes for mods to use

### DIFF
--- a/TavernLib/ModdingApi/TavernModAttribute.cs
+++ b/TavernLib/ModdingApi/TavernModAttribute.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Reflection;
+using MelonLoader;
+
+namespace TavernLib.ModdingApi;
+
+public enum ModSide
+{
+    None,
+    Server,
+    Client,
+    Both,
+}
+
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public class TavernModAttribute : Attribute
+{
+    public ModSide Side { get; }
+    public TavernModAttribute(ModSide side)
+    {
+        Side = side;
+    }
+}
+
+public static class TavernMelonBaseExtension{
+
+    public static ModSide GetModSide(this MelonBase melonMod)
+    {
+        TavernModAttribute modInfo = melonMod.GetType().GetCustomAttribute<TavernModAttribute>();
+        return modInfo?.Side ?? ModSide.None;
+    }
+}

--- a/TavernLib/TavernLib.csproj
+++ b/TavernLib/TavernLib.csproj
@@ -196,6 +196,7 @@
     <Compile Include="Backend\Server\ServerListingPayload.cs" />
     <Compile Include="Backend\BackendUtils.cs" />
     <Compile Include="Backend\WindowsProxy.cs" />
+    <Compile Include="ModdingApi\TavernModAttribute.cs" />
     <Compile Include="ModulePorts\ChunkCommandModule.cs" />
     <Compile Include="ModulePorts\DocumentModule.cs" />
     <Compile Include="ModulePorts\PlayerCommandModule.cs" />


### PR DESCRIPTION
I made a custom atrribute that mod authours could use to provide additional information about their mods that might be necessary for TavernLib to know.

For now it only contains mod sides.
Such as client sided, server sided or both.

This could be used for example to if you wanna check what mods the server wants the client to have. If something is tagged as server only. Then don't ask client to have it before joining.

Example of how a mod authour would use this.
```cs
[TavernMod(ModSide.Client)]
public class MyModMain: MelonMod
{
//Do mod stuff
}
```

and for TavernLib maintainers, getting this value from a MelonMod or anything that inherits from MelonBase.

```cs
MelonBase mod = MelonBase.RegisteredMelons[0];
ModSide side = mod.GetModSide();
```
